### PR TITLE
Remove Azure SignalR Dependency

### DIFF
--- a/Fennorad/Program.cs
+++ b/Fennorad/Program.cs
@@ -64,7 +64,7 @@ builder.Services.AddScoped<IHostEnvironmentAuthenticationStateProvider>(sp => {
 });
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
-builder.Services.AddSignalR().AddAzureSignalR(builder.Configuration.GetValue<string>("Azure:SignalR:ConnectionString"));
+builder.Services.AddSignalR();
 builder.Services.AddScoped<AuthenticationStateProvider, RevalidatingIdentityAuthenticationStateProvider<IdentityUser>>();
 builder.Services.AddResponseCompression(opts =>
 {


### PR DESCRIPTION
After doing some reading, an Blazor Server application can run without the need for Azure SignalR Service. 

The only changes needed
1) Remove the SignalR setup on startup
2) Add Websockets On to the App