### PR TITLE
Fix Youtube Download

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+ffmpeg.exe filter=lfs diff=lfs merge=lfs -text

--- a/Fennorad.Models/Class1.cs
+++ b/Fennorad.Models/Class1.cs
@@ -1,7 +1,0 @@
-﻿namespace Fennorad.Models
-{
-    public class Class1
-    {
-
-    }
-}

--- a/Fennorad.Models/Models/Configuration.cs
+++ b/Fennorad.Models/Models/Configuration.cs
@@ -4,8 +4,8 @@
     {
         public string PythonPath { get; set; }
         public string YoutubeDLPath { get; set; }
-
         public string MapAccessToken { get; set; }
+        public string FfmpegPath { get; set; }
 
     }
 }

--- a/Fennorad/Pages/YoutubeDLPage.razor
+++ b/Fennorad/Pages/YoutubeDLPage.razor
@@ -272,6 +272,7 @@
             var ytdlProc = new YoutubeDLProcess();
             ytdlProc.PythonPath = Config.PythonPath;
             ytdlProc.ExecutablePath = Config.YoutubeDLPath;
+
             // capture the standard output and error output
             ytdlProc.OutputReceived += async (o, e) =>
             {
@@ -301,6 +302,7 @@
                 {
                     Output = filename,
                     MaxFilesize = "20.0m",
+                    FfmpegLocation = Config.FfmpegPath,
                 };
 
             if (mp3Flag)

--- a/Fennorad/Program.cs
+++ b/Fennorad/Program.cs
@@ -23,6 +23,7 @@ builder.Services.AddScoped<Configuration>(opt =>
         PythonPath = builder.Configuration.GetValue<string>("PythonPath"),
         YoutubeDLPath = builder.Configuration.GetValue<string>("YoutubeDLPath"),
         MapAccessToken = builder.Configuration.GetValue<string>("MapAccessToken"),
+        FfmpegPath = builder.Configuration.GetValue<string>("FfmpegPath"),
     };
 });
 

--- a/Fennorad/ffmpeg.exe
+++ b/Fennorad/ffmpeg.exe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e00e43aeb1929d19763ed3ca1e226b3bc81cb50f6b0b04709f1ee504657e2c5
+size 135416832


### PR DESCRIPTION
in checking on the Blazor Server app deployed to Azure I noticed that the youtube downloader doesn't actually download youtube videos. The executable that downloads youtube videos is deprecated so I need to upgrade it to a newer one. `youtube-dl` to `yt-dlp`